### PR TITLE
[iOS] common option select button 기능 업데이트

### DIFF
--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		156A96AB2A8C03D400AE1477 /* QuestionViewSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156A96AA2A8C03D400AE1477 /* QuestionViewSendable.swift */; };
 		156A96AD2A8C57B600AE1477 /* TwoWaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156A96AC2A8C57B600AE1477 /* TwoWaySlider.swift */; };
 		15837B9D2A7E5931000FE728 /* UIControl+CombineInteractionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15837B9C2A7E5931000FE728 /* UIControl+CombineInteractionPublisher.swift */; };
+		15940E802A91F4EC0042A5F5 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15940E7F2A91F4EC0042A5F5 /* UIImage+.swift */; };
 		159B2CF92A825D07003F47D6 /* DetailQuotationPreviewAdapterDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B2CF82A825D07003F47D6 /* DetailQuotationPreviewAdapterDataSource.swift */; };
 		159B2CFE2A825F5F003F47D6 /* CommonQuotationPreviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B2CFD2A825F5F003F47D6 /* CommonQuotationPreviewCell.swift */; };
 		15A738822A8A4B9D009EF6F9 /* DefaultQuotationPreviewThumbnailCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A738812A8A4B9D009EF6F9 /* DefaultQuotationPreviewThumbnailCardView.swift */; };
@@ -227,6 +228,7 @@
 		156A96AA2A8C03D400AE1477 /* QuestionViewSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionViewSendable.swift; sourceTree = "<group>"; };
 		156A96AC2A8C57B600AE1477 /* TwoWaySlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoWaySlider.swift; sourceTree = "<group>"; };
 		15837B9C2A7E5931000FE728 /* UIControl+CombineInteractionPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+CombineInteractionPublisher.swift"; sourceTree = "<group>"; };
+		15940E7F2A91F4EC0042A5F5 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		159B2CF32A82374E003F47D6 /* DetailQuotationPreviewTableViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailQuotationPreviewTableViewAdapter.swift; sourceTree = "<group>"; };
 		159B2CF82A825D07003F47D6 /* DetailQuotationPreviewAdapterDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailQuotationPreviewAdapterDataSource.swift; sourceTree = "<group>"; };
 		159B2CFD2A825F5F003F47D6 /* CommonQuotationPreviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonQuotationPreviewCell.swift; sourceTree = "<group>"; };
@@ -942,6 +944,7 @@
 				15DF959A2A7C8A1D0093EAC7 /* UIFont+.swift */,
 				15DF95982A7C8A110093EAC7 /* UIView+.swift */,
 				6484A7692A8DEDF100434136 /* UIViewController+.swift */,
+				15940E7F2A91F4EC0042A5F5 /* UIImage+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1382,6 +1385,7 @@
 				64ADA4972A7788C10003E2C1 /* Etc.swift in Sources */,
 				15DF959B2A7C8A1D0093EAC7 /* UIFont+.swift in Sources */,
 				64E26A502A8A3E2800F6BC3A /* TrimSubOptionButton.swift in Sources */,
+				15940E802A91F4EC0042A5F5 /* UIImage+.swift in Sources */,
 				64ADA4AD2A78A7090003E2C1 /* CommonButton.swift in Sources */,
 				6484A78A2A903C6A00434136 /* CommonTableHeaderView.swift in Sources */,
 				6484A7902A90444100434136 /* PurchaseView.swift in Sources */,

--- a/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
+++ b/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
@@ -7,7 +7,11 @@
 
 import UIKit
 
-class CommonOptionSelectButton: UIButton {
+protocol CommonOptionSelectViewDelegate: AnyObject {
+    func handleTap(_ sender: UITapGestureRecognizer)
+}
+
+class CommonOptionSelectView: UIView {
     enum Constants {
         static let height: CGFloat = .toScaledHeight(value: 28)
         enum IconImageView {
@@ -51,7 +55,10 @@ class CommonOptionSelectButton: UIButton {
     override var intrinsicContentSize: CGSize {
         return .init(width: .toScaledWidth(value: 69), height: Constants.height)
     }
-    override var isSelected: Bool {
+    
+    var delegate: CommonOptionSelectViewDelegate?
+    
+    var isSelected: Bool = false {
         didSet {
             updateSelectedUIState()
         }
@@ -75,10 +82,15 @@ class CommonOptionSelectButton: UIButton {
     // MARK: - Private functions
     private func configureUI() {
         translatesAutoresizingMaskIntoConstraints = false
+        isUserInteractionEnabled = true
         layer.cornerRadius = Constants.height/2
         layer.borderWidth = 1
         layer.borderColor = UIColor.GetYaPalette.primary.cgColor
         backgroundColor = .white
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(handleTap))
+        addGestureRecognizer(tapGesture)
         setupUI()
     }
     
@@ -97,10 +109,16 @@ class CommonOptionSelectButton: UIButton {
             self.backgroundColor = backgroundColor
         }
     }
+    
+    // MARK: - @Objc function
+    @objc func handleTap(_ sender: UITapGestureRecognizer) {
+        isSelected.toggle()
+        delegate?.handleTap(sender)
+    }
 }
 
 // MARK: - LayoutSupportable
-extension CommonOptionSelectButton: LayoutSupportable {
+extension CommonOptionSelectView: LayoutSupportable {
     func setupViews() {
         addSubviews([
             iconImageView,

--- a/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
+++ b/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
@@ -53,7 +53,7 @@ class CommonOptionSelectButton: UIButton {
     }
     override var isSelected: Bool {
         didSet {
-            isSelected ? configureSelectedState() : configureDeselectedState()
+            updateSelectedUIState()
         }
     }
     
@@ -82,33 +82,19 @@ class CommonOptionSelectButton: UIButton {
         setupUI()
     }
     
-    private func configureSelectedState() {
+    private func updateSelectedUIState() {
+        let selectedColor: UIColor = isSelected ? .white: .GetYaPalette.primary
+        let backgroundColor: UIColor = isSelected ? .GetYaPalette.primary : .white
         UIView.animate(
             withDuration: 0.12,
             delay: 0,
             options: [.curveEaseInOut]
         ) {
-            let color: UIColor = .white
             self.iconImageView.image = self.resizedImage?.withTintColor(
-                color,
+                selectedColor,
                 renderingMode: .alwaysOriginal)
-            self.iconTitleLabel.textColor = color
-            self.backgroundColor = .GetYaPalette.primary
-        }
-    }
-    
-    private func configureDeselectedState() {
-        UIView.animate(
-            withDuration: 0.12,
-            delay: 0,
-            options: [.curveEaseInOut]
-        ) {
-            let primary: UIColor = .GetYaPalette.primary
-            self.iconImageView.image = self.resizedImage?.withTintColor(
-                primary,
-                renderingMode: .alwaysOriginal)
-            self.iconTitleLabel.textColor = primary
-            self.backgroundColor = .white
+            self.iconTitleLabel.textColor = selectedColor
+            self.backgroundColor = backgroundColor
         }
     }
 }

--- a/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
+++ b/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
@@ -8,12 +8,52 @@
 import UIKit
 
 class CommonOptionSelectButton: UIButton {
+    enum Constants {
+        static let height: CGFloat = .toScaledHeight(value: 28)
+        enum IconImageView {
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 14)
+            static let topMargin: CGFloat = .toScaledHeight(value: 6)
+            static let bottomMargin: CGFloat = .toScaledHeight(value: -6)
+            static let width: CGFloat = .toScaledWidth(value: 13)
+            static let height = width
+        }
+        enum IconTitleLabel {
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 8)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -14)
+            static let size: CGSize = {
+                let label = CommonLabel.init(fontType: .mediumCaption1, color: .white, text: "선택")
+                return label.intrinsicContentSize
+            }()
+        }
+    }
+
     // MARK: - UI Properties
+    private let resizedImage: UIImage? = {
+        let image = UIImage(named: "Blue-Check-Circle")
+        let preferSize: CGSize = .init(
+            width: .toScaledWidth(value: 16),
+            height: .toScaledWidth(value: 16))
+        return image?.resize(targetSize: preferSize)
+    }()
+    private lazy var iconImageView = UIImageView(image: resizedImage).set {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.contentMode = .scaleAspectFit
+    }
+    private let iconTitleLabel = CommonLabel.init(
+        fontType: .mediumCaption1,
+        color: .GetYaPalette.primary,
+        text: "선택"
+    ).set {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
     
     // MARK: - Properties
+    override var intrinsicContentSize: CGSize {
+        return .init(width: .toScaledWidth(value: 69), height: Constants.height)
+    }
     override var isSelected: Bool {
         didSet {
-            self.layer.backgroundColor = isSelected ? UIColor(hexString: "00428E").cgColor : UIColor.white.cgColor
+            isSelected ? configureSelectedState() : configureDeselectedState()
         }
     }
     
@@ -32,17 +72,80 @@ class CommonOptionSelectButton: UIButton {
         configureUI()
     }
     
-    // MARK: - Functions
+    // MARK: - Private functions
     private func configureUI() {
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.setTitle("선택", for: .normal)
-        self.setImage(UIImage(named: "Blue-Check-Circle"), for: .normal)
-        self.setImage(UIImage(named: "White-Check-Circle"), for: .selected)
-        self.setTitleColor(UIColor(hexString: "00428E"), for: .normal)
-        self.setTitleColor(.white, for: .selected)
-        self.layer.borderWidth = 1
-        self.layer.borderColor = UIColor(hexString: "00428E").cgColor
-        self.layer.cornerRadius = 20
-        self.layer.backgroundColor = UIColor.white.cgColor
+        translatesAutoresizingMaskIntoConstraints = false
+        layer.cornerRadius = Constants.height/2
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.GetYaPalette.primary.cgColor
+        backgroundColor = .white
+        setupUI()
+    }
+    
+    private func configureSelectedState() {
+        UIView.animate(
+            withDuration: 0.15,
+            delay: 0,
+            options: [.curveEaseInOut]
+        ) {
+            let color: UIColor = .white
+            self.iconImageView.image = self.resizedImage?.withTintColor(
+                color,
+                renderingMode: .alwaysOriginal)
+            self.iconTitleLabel.textColor = color
+            self.backgroundColor = .GetYaPalette.primary
+        }
+    }
+    
+    private func configureDeselectedState() {
+        UIView.animate(
+            withDuration: 0.15,
+            delay: 0,
+            options: [.curveEaseInOut]
+        ) {
+            let primary: UIColor = .GetYaPalette.primary
+            self.iconImageView.image = self.resizedImage?.withTintColor(
+                primary,
+                renderingMode: .alwaysOriginal)
+            self.iconTitleLabel.textColor = primary
+            self.backgroundColor = .white
+        }
+    }
+}
+
+// MARK: - LayoutSupportable
+extension CommonOptionSelectButton: LayoutSupportable {
+    func setupViews() {
+        addSubviews([
+            iconImageView,
+            iconTitleLabel])
+    }
+    
+    func setupConstriants() {
+        configureIconImageView()
+        configureIconTitleLabel()
+    }
+    
+    // MARK: - LayoutSupport private function
+    private func configureIconImageView() {
+        typealias Const = Constants.IconImageView
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Const.leadingMargin),
+            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor)])
+    }
+    
+    private func configureIconTitleLabel() {
+        typealias Const = Constants.IconTitleLabel
+        NSLayoutConstraint.activate([
+            iconTitleLabel.leadingAnchor.constraint(
+                equalTo: iconImageView.trailingAnchor,
+                constant: Const.leadingMargin),
+            iconTitleLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: Const.trailingMargin),
+            iconTitleLabel.centerYAnchor.constraint(
+                equalTo: centerYAnchor)])
     }
 }

--- a/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
+++ b/GetYa/GetYa/Presentation/Common/View/CommonOptionSelectButton.swift
@@ -84,7 +84,7 @@ class CommonOptionSelectButton: UIButton {
     
     private func configureSelectedState() {
         UIView.animate(
-            withDuration: 0.15,
+            withDuration: 0.12,
             delay: 0,
             options: [.curveEaseInOut]
         ) {
@@ -99,7 +99,7 @@ class CommonOptionSelectButton: UIButton {
     
     private func configureDeselectedState() {
         UIView.animate(
-            withDuration: 0.15,
+            withDuration: 0.12,
             delay: 0,
             options: [.curveEaseInOut]
         ) {

--- a/GetYa/GetYa/Util/Extension/UIImage+.swift
+++ b/GetYa/GetYa/Util/Extension/UIImage+.swift
@@ -1,0 +1,8 @@
+//
+//  UIImage+.swift
+//  GetYa
+//
+//  Created by 양승현 on 2023/08/20.
+//
+
+import Foundation

--- a/GetYa/GetYa/Util/Extension/UIImage+.swift
+++ b/GetYa/GetYa/Util/Extension/UIImage+.swift
@@ -5,4 +5,17 @@
 //  Created by 양승현 on 2023/08/20.
 //
 
-import Foundation
+import UIKit
+
+extension UIImage {
+    func resize(targetSize: CGSize, opaque: Bool = false) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(targetSize, opaque, 0)
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        context.interpolationQuality = .high
+        let newRect = CGRect(x: 0, y: 0, width: targetSize.width, height: targetSize.height)
+        draw(in: newRect)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage
+    }
+}


### PR DESCRIPTION
🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [x]  반드시 확인할 것! **pull a topic/feature/bugfix branch** 에서 develop branch로 PR요청하는지 확인하세요. master/main에 하시면 안됩니다.

- [x]  커밋 또는 모든 커밋의 메시지 스타일이 요청한 구조와 일치하는지 확인해주세요.

- [x] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## ✨ [작업 내용]

- CommonOptionSelectButton을 확장했습니다.
  - 선택, 미선택시 피그마에 지정된 배경으로 변경
  - 기본 UIButton에 내장된 ImageView, TitleLabel인,, 선택 icon과 선택 Title간 inner spacing이 되지 않았습니다. 
  
![기존 시도](https://github.com/softeerbootcamp-2nd/H1-MyCarDeepDive/assets/96910404/559b568d-3b2f-45ad-a644-898ef8909114)
이렇게 기존 내장 뷰를 바꿔봤는대 leading은 적용 되지만 imageView, titleLabel사이의 spacing은 0으로 고정되어 있었습니다.
  
그래서 IconImageView, IconTitleLabel로 subview를 추가했습니다.
  
- 여기서 크기를 늘려도 되나, 이미지의 경우 늘어나는데, 텍스트의 경우 CommonLabel의 NSAttributedString타입으로 지정됬기 때문에 텍스트 자체가 늘어나지 않습니다. 그래서 그냥 intrinsicContentSize로 피그마에 있는 크기 + 화면 별 scaledSize로 추가했습니다.

## 📌 [사용 방법]
- PR 개선사항반영

UIView로 반영했습니다!! 그리고 델리게이트를 준수하면 됩니다 : )

![image](https://github.com/softeerbootcamp-2nd/H1-MyCarDeepDive/assets/96910404/8f60709d-9df0-4c88-8ea0-f468a24285f8)



## 📸  [스크린샷(선택)]

![ezgif com-video-to-gif](https://github.com/softeerbootcamp-2nd/H1-MyCarDeepDive/assets/96910404/1fd2d8a8-b8c1-4c12-9312-a058aa0c6212)