### PR TITLE
[iOS] 5.1 화면, 로딩화면 API 모두 연결

### DIFF
--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		6457D1A42A967E7900B3AAAF /* ContractionQuotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */; };
 		6457D1A62A96867400B3AAAF /* ContractionQuotationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */; };
 		6457D1A82A96875300B3AAAF /* PdfIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */; };
+		6457D1AA2A968CE300B3AAAF /* MyActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A92A968CE300B3AAAF /* MyActivityItemSource.swift */; };
 		6484A7372A8C78CF00434136 /* DetailQuotationPreviewViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD062A82D3B2009AE2BC /* DetailQuotationPreviewViewModelable.swift */; };
 		6484A7382A8C78CF00434136 /* DetailQuotationPreviewThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EAB422A81163300833B0E /* DetailQuotationPreviewThumbnailView.swift */; };
 		6484A7392A8C78F400434136 /* QuotationPreviewHeaderTitleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD0D2A840F7D009AE2BC /* QuotationPreviewHeaderTitleList.swift */; };
@@ -441,6 +442,7 @@
 		6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotation.swift; sourceTree = "<group>"; };
 		6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotationDTO.swift; sourceTree = "<group>"; };
 		6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfIdDTO.swift; sourceTree = "<group>"; };
+		6457D1A92A968CE300B3AAAF /* MyActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyActivityItemSource.swift; sourceTree = "<group>"; };
 		6484A7472A8C82FE00434136 /* SubOptionDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubOptionDetailViewController.swift; sourceTree = "<group>"; };
 		6484A7482A8C82FE00434136 /* EngineDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailViewController.swift; sourceTree = "<group>"; };
 		6484A74A2A8C82FE00434136 /* EngineDetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailContentView.swift; sourceTree = "<group>"; };
@@ -876,6 +878,7 @@
 		15DF95A32A7C98C30093EAC7 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				6457D1A92A968CE300B3AAAF /* MyActivityItemSource.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				6457D1702A95D50600B3AAAF /* DefaultQuotationFinishRepository.swift in Sources */,
 				64E26A702A8C076500F6BC3A /* ColorLearnMoreView.swift in Sources */,
 				64ADA4972A7788C10003E2C1 /* Etc.swift in Sources */,
+				6457D1AA2A968CE300B3AAAF /* MyActivityItemSource.swift in Sources */,
 				15DF959B2A7C8A1D0093EAC7 /* UIFont+.swift in Sources */,
 				150636402A9394710057724E /* QuotationDTO.swift in Sources */,
 				64E26A502A8A3E2800F6BC3A /* TrimSubOptionButton.swift in Sources */,

--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -152,6 +152,12 @@
 		6457D17A2A95DF1E00B3AAAF /* OptionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1792A95DF1E00B3AAAF /* OptionInfo.swift */; };
 		6457D17E2A95F96800B3AAAF /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D17D2A95F96800B3AAAF /* UIImageView+.swift */; };
 		6457D18D2A966DC900B3AAAF /* PdfEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D18C2A966DC900B3AAAF /* PdfEmail.swift */; };
+		6457D1982A9678B600B3AAAF /* LoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1972A9678B600B3AAAF /* LoadingViewModel.swift */; };
+		6457D19A2A9678C800B3AAAF /* DefaultLoadingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1992A9678C800B3AAAF /* DefaultLoadingUseCase.swift */; };
+		6457D19C2A967A1200B3AAAF /* LoadingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19B2A967A1200B3AAAF /* LoadingUseCase.swift */; };
+		6457D19E2A967A4500B3AAAF /* DefaultLoadingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19D2A967A4500B3AAAF /* DefaultLoadingRepository.swift */; };
+		6457D1A02A967A5100B3AAAF /* LoadingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */; };
+		6457D1A22A967A6500B3AAAF /* LoadingEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */; };
 		6484A7372A8C78CF00434136 /* DetailQuotationPreviewViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD062A82D3B2009AE2BC /* DetailQuotationPreviewViewModelable.swift */; };
 		6484A7382A8C78CF00434136 /* DetailQuotationPreviewThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EAB422A81163300833B0E /* DetailQuotationPreviewThumbnailView.swift */; };
 		6484A7392A8C78F400434136 /* QuotationPreviewHeaderTitleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD0D2A840F7D009AE2BC /* QuotationPreviewHeaderTitleList.swift */; };
@@ -424,6 +430,12 @@
 		6457D1792A95DF1E00B3AAAF /* OptionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionInfo.swift; sourceTree = "<group>"; };
 		6457D17D2A95F96800B3AAAF /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		6457D18C2A966DC900B3AAAF /* PdfEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfEmail.swift; sourceTree = "<group>"; };
+		6457D1972A9678B600B3AAAF /* LoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewModel.swift; sourceTree = "<group>"; };
+		6457D1992A9678C800B3AAAF /* DefaultLoadingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoadingUseCase.swift; sourceTree = "<group>"; };
+		6457D19B2A967A1200B3AAAF /* LoadingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingUseCase.swift; sourceTree = "<group>"; };
+		6457D19D2A967A4500B3AAAF /* DefaultLoadingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoadingRepository.swift; sourceTree = "<group>"; };
+		6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingRepository.swift; sourceTree = "<group>"; };
+		6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingEndpoint.swift; sourceTree = "<group>"; };
 		6484A7472A8C82FE00434136 /* SubOptionDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubOptionDetailViewController.swift; sourceTree = "<group>"; };
 		6484A7482A8C82FE00434136 /* EngineDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailViewController.swift; sourceTree = "<group>"; };
 		6484A74A2A8C82FE00434136 /* EngineDetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailContentView.swift; sourceTree = "<group>"; };
@@ -777,6 +789,7 @@
 			children = (
 				1506363B2A9392150057724E /* QuotationEndpoint.swift */,
 				6457D1712A95D51600B3AAAF /* QuotationFinishEndpoint.swift */,
+				6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */,
 			);
 			path = Endpoint;
 			sourceTree = "<group>";
@@ -1028,6 +1041,31 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		6457D1922A96789300B3AAAF /* Loading */ = {
+			isa = PBXGroup;
+			children = (
+				6457D1962A9678AC00B3AAAF /* ViewController */,
+				6457D1952A9678A800B3AAAF /* ViewModel */,
+			);
+			path = Loading;
+			sourceTree = "<group>";
+		};
+		6457D1952A9678A800B3AAAF /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				6457D1972A9678B600B3AAAF /* LoadingViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		6457D1962A9678AC00B3AAAF /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				6484A7732A8E4CD100434136 /* LoadingViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		647FBF132A7CB5C900507AE9 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -1065,7 +1103,6 @@
 				6484A75F2A8CB86F00434136 /* AlertViewController.swift */,
 				156A96A12A8BD5A100AE1477 /* BaseCharacterSelectPageViewController.swift */,
 				156A96A42A8BD66D00AE1477 /* BaseViewController.swift */,
-				6484A7732A8E4CD100434136 /* LoadingViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1158,6 +1195,7 @@
 				156A969C2A8BD19400AE1477 /* CharacterDetailSelect */,
 				155729FD2A8954E200D136C6 /* QuotationPreview */,
 				64E26A0E2A895B9C00F6BC3A /* CarSettingSelect */,
+				6457D1922A96789300B3AAAF /* Loading */,
 				6484A77C2A8F136000434136 /* QuotationFinish */,
 				64ADA4742A7787C60003E2C1 /* Coordinator */,
 			);
@@ -1313,6 +1351,7 @@
 				64ADA47E2A77884D0003E2C1 /* Protocol */,
 				6457D1352A9498B200B3AAAF /* DefaultCarSettingUseCase.swift */,
 				6457D16B2A95D4DE00B3AAAF /* DefaultQuotationFinishUseCase.swift */,
+				6457D1992A9678C800B3AAAF /* DefaultLoadingUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -1326,6 +1365,7 @@
 				6457D1312A94988600B3AAAF /* ColorSelectUseCase.swift */,
 				6457D1332A94989100B3AAAF /* OptionSelectUseCase.swift */,
 				6457D16D2A95D4EA00B3AAAF /* QuotationFinishUseCase.swift */,
+				6457D19B2A967A1200B3AAAF /* LoadingUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1362,6 +1402,7 @@
 				64ADA4822A77886F0003E2C1 /* Protocol */,
 				150636432A93AA560057724E /* DefaultQuotationRepository.swift */,
 				6457D16F2A95D50600B3AAAF /* DefaultQuotationFinishRepository.swift */,
+				6457D19D2A967A4500B3AAAF /* DefaultLoadingRepository.swift */,
 			);
 			path = Repositoy;
 			sourceTree = "<group>";
@@ -1387,6 +1428,7 @@
 				64ADA4882A77888C0003E2C1 /* RepositoyProtocol.swift */,
 				150636412A93A8F00057724E /* QuotationRepository.swift */,
 				6457D1732A95D54000B3AAAF /* QuotationFinishRepository.swift */,
+				6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1750,6 +1792,7 @@
 				15E1D21C2A8EFA670048DAC7 /* DefaultQuotationPreviewViewModel.swift in Sources */,
 				155ED7222A7E5BE50052896A /* UITextField+Combine.swift in Sources */,
 				6457CFB62A9395D100B3AAAF /* OptionDetail.swift in Sources */,
+				6457D1A22A967A6500B3AAAF /* LoadingEndpoint.swift in Sources */,
 				6457D1122A945C6E00B3AAAF /* AdditionalOptionViewController.swift in Sources */,
 				155EAB3A2A80824B00833B0E /* DetailQuotationPreviewViewController.swift in Sources */,
 				155DDD0A2A835FEF009AE2BC /* DetailQuotationPreviewSecionHeaderView.swift in Sources */,
@@ -1788,6 +1831,7 @@
 				64ADA4AD2A78A7090003E2C1 /* CommonButton.swift in Sources */,
 				15D026392A94B068001D1659 /* OptionInfoDTO.swift in Sources */,
 				6484A78A2A903C6A00434136 /* CommonTableHeaderView.swift in Sources */,
+				6457D1982A9678B600B3AAAF /* LoadingViewModel.swift in Sources */,
 				6484A7A12A91F40800434136 /* OptionSelectItemLearnMoreView.swift in Sources */,
 				6484A7902A90444100434136 /* PurchaseView.swift in Sources */,
 				6484A7822A8F266A00434136 /* QuotationFinishTableCell.swift in Sources */,
@@ -1800,6 +1844,7 @@
 				15DF95972A7C89F50093EAC7 /* UIColor+GetYaPalette.swift in Sources */,
 				64E26A4F2A8A3E2800F6BC3A /* TrimTooltipView.swift in Sources */,
 				15E1D21A2A8EF4F60048DAC7 /* DefaultQuotationPreviewTableView.swift in Sources */,
+				6457D19E2A967A4500B3AAAF /* DefaultLoadingRepository.swift in Sources */,
 				6484A79B2A90F3E800434136 /* AdditionalCollectionView.swift in Sources */,
 				15D0263C2A94BB12001D1659 /* DefaultQuotationPreviewViewController.swift in Sources */,
 				64ADA4BE2A7A26090003E2C1 /* Int+.swift in Sources */,
@@ -1834,11 +1879,13 @@
 				155B72B22A8CA02D0091A7F4 /* CharacterDetailSelectViewModel.swift in Sources */,
 				6412D08C2A81E5C1001E4005 /* LifeStylePeekViewController.swift in Sources */,
 				155ED71E2A7E5AD60052896A /* UIControl+Publihser.swift in Sources */,
+				6457D19C2A967A1200B3AAAF /* LoadingUseCase.swift in Sources */,
 				155ED7242A7E6D5A0052896A /* ViewModelable.swift in Sources */,
 				1506363C2A9392150057724E /* QuotationEndpoint.swift in Sources */,
 				64ADA48D2A77889D0003E2C1 /* Protocol.swift in Sources */,
 				641AB5262A7BA07300CF88C0 /* CheckListStackView.swift in Sources */,
 				6457D1362A9498B200B3AAAF /* DefaultCarSettingUseCase.swift in Sources */,
+				6457D1A02A967A5100B3AAAF /* LoadingRepository.swift in Sources */,
 				156A96A82A8C03A300AE1477 /* CharacterDetailQuestionListView.swift in Sources */,
 				156A969F2A8BD1BE00AE1477 /* CharacterDetailSelectViewController.swift in Sources */,
 				6457D11F2A945C9500B3AAAF /* OptionSelectImageCell.swift in Sources */,
@@ -1896,6 +1943,7 @@
 				6457D1742A95D54000B3AAAF /* QuotationFinishRepository.swift in Sources */,
 				6412D07C2A7E607D001E4005 /* LifeStyleCell.swift in Sources */,
 				155DDD162A84A808009AE2BC /* DetailQuotationPreviewFooterView.swift in Sources */,
+				6457D19A2A9678C800B3AAAF /* DefaultLoadingUseCase.swift in Sources */,
 				155B72AF2A8CA0020091A7F4 /* QuestionDescriptionLabelModel+Mock.swift in Sources */,
 				155ED7202A7E5B890052896A /* UIButton+Combine.swift in Sources */,
 				15E1D2162A8EF3D10048DAC7 /* DefaultQuotationPreviewMainHeader.swift in Sources */,

--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		6457D19E2A967A4500B3AAAF /* DefaultLoadingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19D2A967A4500B3AAAF /* DefaultLoadingRepository.swift */; };
 		6457D1A02A967A5100B3AAAF /* LoadingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */; };
 		6457D1A22A967A6500B3AAAF /* LoadingEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */; };
+		6457D1A42A967E7900B3AAAF /* ContractionQuotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */; };
 		6484A7372A8C78CF00434136 /* DetailQuotationPreviewViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD062A82D3B2009AE2BC /* DetailQuotationPreviewViewModelable.swift */; };
 		6484A7382A8C78CF00434136 /* DetailQuotationPreviewThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EAB422A81163300833B0E /* DetailQuotationPreviewThumbnailView.swift */; };
 		6484A7392A8C78F400434136 /* QuotationPreviewHeaderTitleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD0D2A840F7D009AE2BC /* QuotationPreviewHeaderTitleList.swift */; };
@@ -205,7 +206,6 @@
 		64ADA4632A7787780003E2C1 /* GetYaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA4622A7787780003E2C1 /* GetYaUITestsLaunchTests.swift */; };
 		64ADA4852A77887E0003E2C1 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA4842A77887E0003E2C1 /* AppCoordinator.swift */; };
 		64ADA4892A77888C0003E2C1 /* RepositoyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA4882A77888C0003E2C1 /* RepositoyProtocol.swift */; };
-		64ADA48B2A7788900003E2C1 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA48A2A7788900003E2C1 /* Entity.swift */; };
 		64ADA48D2A77889D0003E2C1 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA48C2A77889D0003E2C1 /* Protocol.swift */; };
 		64ADA48F2A7788AA0003E2C1 /* PresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA48E2A7788AA0003E2C1 /* PresentationCoordinator.swift */; };
 		64ADA4912A7788B00003E2C1 /* CommonProtocl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64ADA4902A7788B00003E2C1 /* CommonProtocl.swift */; };
@@ -436,6 +436,7 @@
 		6457D19D2A967A4500B3AAAF /* DefaultLoadingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoadingRepository.swift; sourceTree = "<group>"; };
 		6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingRepository.swift; sourceTree = "<group>"; };
 		6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingEndpoint.swift; sourceTree = "<group>"; };
+		6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotation.swift; sourceTree = "<group>"; };
 		6484A7472A8C82FE00434136 /* SubOptionDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubOptionDetailViewController.swift; sourceTree = "<group>"; };
 		6484A7482A8C82FE00434136 /* EngineDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailViewController.swift; sourceTree = "<group>"; };
 		6484A74A2A8C82FE00434136 /* EngineDetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailContentView.swift; sourceTree = "<group>"; };
@@ -477,7 +478,6 @@
 		64ADA4622A7787780003E2C1 /* GetYaUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetYaUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		64ADA4842A77887E0003E2C1 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		64ADA4882A77888C0003E2C1 /* RepositoyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoyProtocol.swift; sourceTree = "<group>"; };
-		64ADA48A2A7788900003E2C1 /* Entity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		64ADA48C2A77889D0003E2C1 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		64ADA48E2A7788AA0003E2C1 /* PresentationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationCoordinator.swift; sourceTree = "<group>"; };
 		64ADA4902A7788B00003E2C1 /* CommonProtocl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonProtocl.swift; sourceTree = "<group>"; };
@@ -1377,7 +1377,6 @@
 				6457CFAB2A93941D00B3AAAF /* AdditionalOptionList.swift */,
 				6457CFAD2A93942D00B3AAAF /* AdditionalOptionPackage.swift */,
 				6457CFB32A93959B00B3AAAF /* BasicOption.swift */,
-				64ADA48A2A7788900003E2C1 /* Entity.swift */,
 				6457CFB52A9395D100B3AAAF /* OptionDetail.swift */,
 				6457D1792A95DF1E00B3AAAF /* OptionInfo.swift */,
 				6457CFB72A93960500B3AAAF /* PackageOptionDetail.swift */,
@@ -1392,6 +1391,7 @@
 				6457D1252A9465A500B3AAAF /* OptionSelectModel.swift */,
 				6457D1772A95DE6300B3AAAF /* QuotationFinish.swift */,
 				6457D18C2A966DC900B3AAAF /* PdfEmail.swift */,
+				6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1844,6 +1844,7 @@
 				15DF95972A7C89F50093EAC7 /* UIColor+GetYaPalette.swift in Sources */,
 				64E26A4F2A8A3E2800F6BC3A /* TrimTooltipView.swift in Sources */,
 				15E1D21A2A8EF4F60048DAC7 /* DefaultQuotationPreviewTableView.swift in Sources */,
+				6457D1A42A967E7900B3AAAF /* ContractionQuotation.swift in Sources */,
 				6457D19E2A967A4500B3AAAF /* DefaultLoadingRepository.swift in Sources */,
 				6484A79B2A90F3E800434136 /* AdditionalCollectionView.swift in Sources */,
 				15D0263C2A94BB12001D1659 /* DefaultQuotationPreviewViewController.swift in Sources */,
@@ -1859,7 +1860,6 @@
 				641AB5222A7B7D2A00CF88C0 /* HomeContentView.swift in Sources */,
 				64ADA4852A77887E0003E2C1 /* AppCoordinator.swift in Sources */,
 				64E26A102A895C0F00F6BC3A /* ColorSelectViewController.swift in Sources */,
-				64ADA48B2A7788900003E2C1 /* Entity.swift in Sources */,
 				6457D1302A948EA200B3AAAF /* TrimSelectUseCase.swift in Sources */,
 				6484A7922A904BA200434136 /* PurchaseLearnMoreView.swift in Sources */,
 				64E26A492A8A3E2800F6BC3A /* BottomSheetSmallContentView.swift in Sources */,

--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		6457D1A02A967A5100B3AAAF /* LoadingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */; };
 		6457D1A22A967A6500B3AAAF /* LoadingEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */; };
 		6457D1A42A967E7900B3AAAF /* ContractionQuotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */; };
+		6457D1A62A96867400B3AAAF /* ContractionQuotationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */; };
+		6457D1A82A96875300B3AAAF /* PdfIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */; };
 		6484A7372A8C78CF00434136 /* DetailQuotationPreviewViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD062A82D3B2009AE2BC /* DetailQuotationPreviewViewModelable.swift */; };
 		6484A7382A8C78CF00434136 /* DetailQuotationPreviewThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EAB422A81163300833B0E /* DetailQuotationPreviewThumbnailView.swift */; };
 		6484A7392A8C78F400434136 /* QuotationPreviewHeaderTitleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD0D2A840F7D009AE2BC /* QuotationPreviewHeaderTitleList.swift */; };
@@ -437,6 +439,8 @@
 		6457D19F2A967A5100B3AAAF /* LoadingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingRepository.swift; sourceTree = "<group>"; };
 		6457D1A12A967A6500B3AAAF /* LoadingEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingEndpoint.swift; sourceTree = "<group>"; };
 		6457D1A32A967E7900B3AAAF /* ContractionQuotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotation.swift; sourceTree = "<group>"; };
+		6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotationDTO.swift; sourceTree = "<group>"; };
+		6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfIdDTO.swift; sourceTree = "<group>"; };
 		6484A7472A8C82FE00434136 /* SubOptionDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubOptionDetailViewController.swift; sourceTree = "<group>"; };
 		6484A7482A8C82FE00434136 /* EngineDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailViewController.swift; sourceTree = "<group>"; };
 		6484A74A2A8C82FE00434136 /* EngineDetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailContentView.swift; sourceTree = "<group>"; };
@@ -1418,6 +1422,8 @@
 				1506363F2A9394710057724E /* QuotationDTO.swift */,
 				6457D1752A95DD0000B3AAAF /* QuotationFinishDTO.swift */,
 				15D2ABC52A9357C100F7DE8E /* TrimCarSpec.swift */,
+				6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */,
+				6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1784,6 +1790,7 @@
 				641AB5202A7B7CF400CF88C0 /* CharacterSelectViewController.swift in Sources */,
 				64ADA4952A7788BC0003E2C1 /* CommonViewModel.swift in Sources */,
 				6457D1112A945C6E00B3AAAF /* BasicOptionViewController.swift in Sources */,
+				6457D1A82A96875300B3AAAF /* PdfIdDTO.swift in Sources */,
 				15A738822A8A4B9D009EF6F9 /* DefaultQuotationPreviewThumbnailCardView.swift in Sources */,
 				15A738842A8A8E1B009EF6F9 /* DefaultQuotationPreviewThumbnailView.swift in Sources */,
 				64E26A572A8A3E2800F6BC3A /* TrimLearnMoreView.swift in Sources */,
@@ -1801,6 +1808,7 @@
 				15040FC92A8E4C5E00DDC411 /* TagViewCell.swift in Sources */,
 				159B2CF92A825D07003F47D6 /* DetailQuotationPreviewAdapterDataSource.swift in Sources */,
 				6457D11A2A945C9500B3AAAF /* BasicCollectionView.swift in Sources */,
+				6457D1A62A96867400B3AAAF /* ContractionQuotationDTO.swift in Sources */,
 				159B2CFE2A825F5F003F47D6 /* CommonQuotationPreviewCell.swift in Sources */,
 				641AB5282A7BA0F300CF88C0 /* CheckListItemView.swift in Sources */,
 				6412D0BF2A87C248001E4005 /* CommonPaddingLabel.swift in Sources */,

--- a/GetYa/GetYa.xcodeproj/project.pbxproj
+++ b/GetYa/GetYa.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		6457D1A62A96867400B3AAAF /* ContractionQuotationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */; };
 		6457D1A82A96875300B3AAAF /* PdfIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */; };
 		6457D1AA2A968CE300B3AAAF /* MyActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1A92A968CE300B3AAAF /* MyActivityItemSource.swift */; };
+		6457D1AC2A96963700B3AAAF /* PdfUrlDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6457D1AB2A96963700B3AAAF /* PdfUrlDTO.swift */; };
 		6484A7372A8C78CF00434136 /* DetailQuotationPreviewViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD062A82D3B2009AE2BC /* DetailQuotationPreviewViewModelable.swift */; };
 		6484A7382A8C78CF00434136 /* DetailQuotationPreviewThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EAB422A81163300833B0E /* DetailQuotationPreviewThumbnailView.swift */; };
 		6484A7392A8C78F400434136 /* QuotationPreviewHeaderTitleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DDD0D2A840F7D009AE2BC /* QuotationPreviewHeaderTitleList.swift */; };
@@ -443,6 +444,7 @@
 		6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractionQuotationDTO.swift; sourceTree = "<group>"; };
 		6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfIdDTO.swift; sourceTree = "<group>"; };
 		6457D1A92A968CE300B3AAAF /* MyActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyActivityItemSource.swift; sourceTree = "<group>"; };
+		6457D1AB2A96963700B3AAAF /* PdfUrlDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfUrlDTO.swift; sourceTree = "<group>"; };
 		6484A7472A8C82FE00434136 /* SubOptionDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubOptionDetailViewController.swift; sourceTree = "<group>"; };
 		6484A7482A8C82FE00434136 /* EngineDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailViewController.swift; sourceTree = "<group>"; };
 		6484A74A2A8C82FE00434136 /* EngineDetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineDetailContentView.swift; sourceTree = "<group>"; };
@@ -1427,6 +1429,7 @@
 				15D2ABC52A9357C100F7DE8E /* TrimCarSpec.swift */,
 				6457D1A52A96867400B3AAAF /* ContractionQuotationDTO.swift */,
 				6457D1A72A96875300B3AAAF /* PdfIdDTO.swift */,
+				6457D1AB2A96963700B3AAAF /* PdfUrlDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1922,6 +1925,7 @@
 				6457CFAC2A93941D00B3AAAF /* AdditionalOptionList.swift in Sources */,
 				155B72A32A8C88570091A7F4 /* BottomSheetView.swift in Sources */,
 				155B72AB2A8C9A2E0091A7F4 /* UIColor+.swift in Sources */,
+				6457D1AC2A96963700B3AAAF /* PdfUrlDTO.swift in Sources */,
 				15040FC22A8D3CAB00DDC411 /* DetailQuestionCarPriceSelectView.swift in Sources */,
 				150636392A9389270057724E /* DiskCache.swift in Sources */,
 				155776E12A90D27300E3C0E1 /* Endpoint.swift in Sources */,

--- a/GetYa/GetYa/App/SceneDelegate.swift
+++ b/GetYa/GetYa/App/SceneDelegate.swift
@@ -48,6 +48,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
+    func removeAllViewContrllerExcept(to viewController: UIViewController, nextViewController: UIViewController) {
+        guard let navigationController = self.window?.rootViewController as? UINavigationController,
+              let viewControllerIndex = navigationController.viewControllers.firstIndex(of: viewController)
+        else { return }
+        navigationController.pushViewController(nextViewController, animated: true)
+        navigationController.viewControllers = navigationController
+            .viewControllers
+            .enumerated()
+            .filter { (idx, viewController) in
+                if idx <= viewControllerIndex {
+                    return true
+                } else if viewController == nextViewController {
+                    return true
+                }
+                return false
+            }
+            .map { $0.element }
+    }
 }
 

--- a/GetYa/GetYa/Data/DTO/ContractionQuotationDTO.swift
+++ b/GetYa/GetYa/Data/DTO/ContractionQuotationDTO.swift
@@ -1,0 +1,32 @@
+//
+//  ContractionQuotationDTO.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+
+struct ContractionQuotationDTO: Codable {
+    let carSpecID: Int
+    let trimID: Int
+    let exteriorColorID: Int
+    let interiorColorID: Int
+    let additionalOptionIDList: [Int]
+    
+    enum CodingKeys: String, CodingKey {
+        case carSpecID = "car_spec_id"
+        case trimID = "trim_id"
+        case exteriorColorID = "exterior_color_id"
+        case interiorColorID = "interior_color_id"
+        case additionalOptionIDList = "additional_option_id_list"
+    }
+    
+    init(contractionQuotation: ContractionQuotation) {
+        self.carSpecID = contractionQuotation.carSpecID
+        self.trimID = contractionQuotation.trimID
+        self.exteriorColorID = contractionQuotation.exteriorColorID
+        self.interiorColorID = contractionQuotation.interiorColorID
+        self.additionalOptionIDList = contractionQuotation.additionalOptionIDList
+    }
+}

--- a/GetYa/GetYa/Data/DTO/PdfIdDTO.swift
+++ b/GetYa/GetYa/Data/DTO/PdfIdDTO.swift
@@ -1,0 +1,21 @@
+//
+//  PdfID.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+
+struct PdfIdDTO: Codable {
+    let pdfID: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case pdfID = "pdfId"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pdfID = try? container.decode(String.self, forKey: .pdfID)
+    }
+}

--- a/GetYa/GetYa/Data/DTO/PdfUrlDTO.swift
+++ b/GetYa/GetYa/Data/DTO/PdfUrlDTO.swift
@@ -1,0 +1,21 @@
+//
+//  PdfUrlDTO.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+
+struct PdfUrlDTO: Codable {
+    let pdfURL: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case pdfURL = "pdfUrl"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pdfURL = try? container.decode(String.self, forKey: .pdfURL)
+    }
+}

--- a/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
+++ b/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
@@ -11,9 +11,10 @@ struct LoadingEndpoint {
     private init() {}
     static let shared = LoadingEndpoint()
     
-    func fetchPdfID(with request: ContractionQuotation) -> Endpoint<String> {
+    func fetchPdfID(with request: ContractionQuotation) -> Endpoint<PdfIdDTO> {
         return Endpoint(
             method: .post,
-            responseType: .pdfID)
+            responseType: .pdfID,
+            bodyParameters: request.toDTO())
     }
 }

--- a/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
+++ b/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
@@ -11,17 +11,9 @@ struct LoadingEndpoint {
     private init() {}
     static let shared = LoadingEndpoint()
     
-    func fetchCarInquery(
-        with request: String
-    ) -> Endpoint<QuotationFinishDTO> {
-        return Endpoint<QuotationFinishDTO>(
-            method: .get,
-            responseType: .pdfCarInfomation(pdfID: request))
-    }
-    
-    func fetchPdfEmail(with request: PdfEmail) -> Endpoint<Bool> {
-        return Endpoint<Bool>(
-            method: .get,
-            responseType: .pdfEmail(pdfEmail: request))
+    func fetchPdfID(with request: ContractionQuotation) -> Endpoint<String> {
+        return Endpoint(
+            method: .post,
+            responseType: .pdfID)
     }
 }

--- a/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
+++ b/GetYa/GetYa/Data/Endpoint/LoadingEndpoint.swift
@@ -1,0 +1,27 @@
+//
+//  LoadingEndpoint.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+
+struct LoadingEndpoint {
+    private init() {}
+    static let shared = LoadingEndpoint()
+    
+    func fetchCarInquery(
+        with request: String
+    ) -> Endpoint<QuotationFinishDTO> {
+        return Endpoint<QuotationFinishDTO>(
+            method: .get,
+            responseType: .pdfCarInfomation(pdfID: request))
+    }
+    
+    func fetchPdfEmail(with request: PdfEmail) -> Endpoint<Bool> {
+        return Endpoint<Bool>(
+            method: .get,
+            responseType: .pdfEmail(pdfEmail: request))
+    }
+}

--- a/GetYa/GetYa/Data/Endpoint/QuotationFinishEndpoint.swift
+++ b/GetYa/GetYa/Data/Endpoint/QuotationFinishEndpoint.swift
@@ -24,4 +24,10 @@ struct QuotationFinishEndpoint {
             method: .get,
             responseType: .pdfEmail(pdfEmail: request))
     }
+    
+    func fetchPdfURL(with request: String) -> Endpoint<PdfUrlDTO> {
+        return Endpoint<PdfUrlDTO>(
+            method: .get,
+            responseType: .pdfURL(pdfID: request))
+    }
 }

--- a/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
@@ -16,9 +16,9 @@ class DefaultLoadingRepository: LoadingRepository {
         self.provider = provider
     }
     
-    func fetchPdfID(with request: ContractionQuotation) async throws -> String {
+    func fetchPdfID(with request: ContractionQuotation) async throws -> String? {
         let endpoint = Endpoint.shared.fetchPdfID(with: request)
         let commonDTO = try await provider.request(endpoint: endpoint)
-        return commonDTO.data
+        return commonDTO.data.pdfID
     }
 }

--- a/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
@@ -16,16 +16,8 @@ class DefaultLoadingRepository: LoadingRepository {
         self.provider = provider
     }
     
-    func fetchCarInquery(
-        with request: String
-    ) async throws -> QuotationFinish {
-        let endpoint = Endpoint.shared.fetchCarInquery(with: request)
-        let commonDTO = try await provider.request(endpoint: endpoint)
-        return commonDTO.data.toDomain()
-    }
-    
-    func fetchPdfEmail(with request: PdfEmail) async throws -> Bool {
-        let endpoint = Endpoint.shared.fetchPdfEmail(with: request)
+    func fetchPdfID(with request: ContractionQuotation) async throws -> String {
+        let endpoint = Endpoint.shared.fetchPdfID(with: request)
         let commonDTO = try await provider.request(endpoint: endpoint)
         return commonDTO.data
     }

--- a/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/DefaultLoadingRepository.swift
@@ -1,0 +1,32 @@
+//
+//  DefaultLoadingRepository.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+import Combine
+
+class DefaultLoadingRepository: LoadingRepository {
+    typealias Endpoint = LoadingEndpoint
+    private let provider: EndpointProvider
+    
+    init(provider: EndpointProvider) {
+        self.provider = provider
+    }
+    
+    func fetchCarInquery(
+        with request: String
+    ) async throws -> QuotationFinish {
+        let endpoint = Endpoint.shared.fetchCarInquery(with: request)
+        let commonDTO = try await provider.request(endpoint: endpoint)
+        return commonDTO.data.toDomain()
+    }
+    
+    func fetchPdfEmail(with request: PdfEmail) async throws -> Bool {
+        let endpoint = Endpoint.shared.fetchPdfEmail(with: request)
+        let commonDTO = try await provider.request(endpoint: endpoint)
+        return commonDTO.data
+    }
+}

--- a/GetYa/GetYa/Data/Repositoy/DefaultQuotationFinishRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/DefaultQuotationFinishRepository.swift
@@ -29,4 +29,10 @@ struct DefaultQuotationFinishRepository: QuotationFinishRepository {
         let commonDTO = try await provider.request(endpoint: endpoint)
         return commonDTO.data
     }
+    
+    func fetchPdfURL(with request: String) async throws -> String? {
+        let endpoint = Endpoint.shared.fetchPdfURL(with: request)
+        let commonDTO = try await provider.request(endpoint: endpoint)
+        return commonDTO.data.pdfURL
+    }
 }

--- a/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 import Combine
 
 protocol LoadingRepository {
-    
+    func fetchPdfID(with request: ContractionQuotation) async throws -> String
 }

--- a/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 import Combine
 
 protocol LoadingRepository {
-    func fetchPdfID(with request: ContractionQuotation) async throws -> String
+    func fetchPdfID(with request: ContractionQuotation) async throws -> String?
 }

--- a/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/Protocol/LoadingRepository.swift
@@ -1,0 +1,13 @@
+//
+//  LoadingRepository.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+import Combine
+
+protocol LoadingRepository {
+    
+}

--- a/GetYa/GetYa/Data/Repositoy/Protocol/QuotationFinishRepository.swift
+++ b/GetYa/GetYa/Data/Repositoy/Protocol/QuotationFinishRepository.swift
@@ -11,4 +11,5 @@ import Combine
 protocol QuotationFinishRepository {
     func fetchCarInquery(with request: String) async throws -> QuotationFinish
     func fetchPdfEmail(with request: PdfEmail) async throws -> Bool
+    func fetchPdfURL(with request: String) async throws -> String?
 }

--- a/GetYa/GetYa/Domain/Entity/ContractionQuotation.swift
+++ b/GetYa/GetYa/Domain/Entity/ContractionQuotation.swift
@@ -1,0 +1,16 @@
+//
+//  ContractionQuotation.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+
+struct ContractionQuotation: Codable {
+    let carSpecID: Int
+    let trimID: Int
+    let exteriorColorID: Int
+    let interiorColorID: Int
+    let additionalOptionIDList: [Int]
+}

--- a/GetYa/GetYa/Domain/Entity/ContractionQuotation.swift
+++ b/GetYa/GetYa/Domain/Entity/ContractionQuotation.swift
@@ -13,4 +13,8 @@ struct ContractionQuotation: Codable {
     let exteriorColorID: Int
     let interiorColorID: Int
     let additionalOptionIDList: [Int]
+    
+    func toDTO() -> ContractionQuotationDTO {
+        return ContractionQuotationDTO(contractionQuotation: self)
+    }
 }

--- a/GetYa/GetYa/Domain/Entity/Entity.swift
+++ b/GetYa/GetYa/Domain/Entity/Entity.swift
@@ -1,8 +1,0 @@
-//
-//  Entity.swift
-//  GetYa
-//
-//  Created by 배남석 on 2023/07/31.
-//
-
-import Foundation

--- a/GetYa/GetYa/Domain/Entity/TrimSubOptionSelectModel.swift
+++ b/GetYa/GetYa/Domain/Entity/TrimSubOptionSelectModel.swift
@@ -11,10 +11,4 @@ struct TrimSubOptionSelectModel {
     var engineID: Int
     var bodyID: Int
     var drivingSystemID: Int
-    
-    init(engineID: Int, bodyID: Int, drivingSystemID: Int) {
-        self.engineID = engineID
-        self.bodyID = bodyID
-        self.drivingSystemID = drivingSystemID
-    }
 }

--- a/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
@@ -9,6 +9,11 @@ import Foundation
 import Combine
 
 class DefaultLoadingUseCase: LoadingUseCase {
+    enum LoadingUseCaseError: Error {
+        case wrongDecode
+        case wrongPdfID
+    }
+    
     // MARK: - Dependency
     var pdfID = PassthroughSubject<String, Never>()
     
@@ -26,6 +31,7 @@ class DefaultLoadingUseCase: LoadingUseCase {
         Task(operation: {
             do {
                 let pdfID = try await repository.fetchPdfID(with: contrationQuotation)
+                guard let pdfID else { throw LoadingUseCaseError.wrongPdfID }
                 self.pdfID.send(pdfID)
             } catch {
                 print("PDF ID를 받아오지 못했습니다.")

--- a/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
@@ -10,6 +10,7 @@ import Combine
 
 class DefaultLoadingUseCase: LoadingUseCase {
     // MARK: - Dependency
+    var pdfID = PassthroughSubject<String, Never>()
     
     // MARK: - Properties
     private let repository: LoadingRepository
@@ -21,4 +22,14 @@ class DefaultLoadingUseCase: LoadingUseCase {
     }
     
     // MARK: - Functions
+    func fetchPdfID(contrationQuotation: ContractionQuotation) {
+        Task(operation: {
+            do {
+                let pdfID = try await repository.fetchPdfID(with: contrationQuotation)
+                self.pdfID.send(pdfID)
+            } catch {
+                print("PDF ID를 받아오지 못했습니다.")
+            }
+        })
+    }
 }

--- a/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/DefaultLoadingUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  DefaultLoadingUseCase.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+import Combine
+
+class DefaultLoadingUseCase: LoadingUseCase {
+    // MARK: - Dependency
+    
+    // MARK: - Properties
+    private let repository: LoadingRepository
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - LifeCycle
+    init(repository: LoadingRepository) {
+        self.repository = repository
+    }
+    
+    // MARK: - Functions
+}

--- a/GetYa/GetYa/Domain/UseCase/DefaultQuotationFinishUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/DefaultQuotationFinishUseCase.swift
@@ -14,7 +14,7 @@ class DefaultQuotationFinishUseCase: QuotationFinishUseCase {
     // MARK: - Properties
     private let repository: QuotationFinishRepository
     private var cancellabels = Set<AnyCancellable>()
-    var pdfID = CurrentValueSubject<String, Never>("64e478c8980e0b4882d3eef5")
+    var pdfID = CurrentValueSubject<String, Never>("")
     var carInquery = PassthroughSubject<QuotationFinish, Never>()
     var emailResult = PassthroughSubject<Bool, Never>()
     

--- a/GetYa/GetYa/Domain/UseCase/DefaultQuotationFinishUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/DefaultQuotationFinishUseCase.swift
@@ -17,6 +17,7 @@ class DefaultQuotationFinishUseCase: QuotationFinishUseCase {
     var pdfID = CurrentValueSubject<String, Never>("")
     var carInquery = PassthroughSubject<QuotationFinish, Never>()
     var emailResult = PassthroughSubject<Bool, Never>()
+    var pdfURL = PassthroughSubject<String, Never>()
     
     // MARK: - LifeCycle
     init(pdfID: String, repository: QuotationFinishRepository) {
@@ -45,6 +46,18 @@ class DefaultQuotationFinishUseCase: QuotationFinishUseCase {
                 self.emailResult.send(emailResult)
             } catch {
                 print("이메일 전송을 실패하였습니다.")
+            }
+        })
+    }
+    
+    func fetchPdfURL() {
+        Task(operation: {
+            do {
+                let pdfURL = try await repository.fetchPdfURL(with: pdfID.value)
+                guard let pdfURL else { return }
+                self.pdfURL.send(pdfURL)
+            } catch {
+                print("PDF 파일 다운로드를 실패하였습니다.")
             }
         })
     }

--- a/GetYa/GetYa/Domain/UseCase/Protocol/LoadingUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/Protocol/LoadingUseCase.swift
@@ -9,5 +9,6 @@ import Foundation
 import Combine
 
 protocol LoadingUseCase {
-    
+    var pdfID: PassthroughSubject<String, Never> { get set }
+    func fetchPdfID(contrationQuotation: ContractionQuotation)
 }

--- a/GetYa/GetYa/Domain/UseCase/Protocol/LoadingUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/Protocol/LoadingUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  LoadingUseCase.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+import Combine
+
+protocol LoadingUseCase {
+    
+}

--- a/GetYa/GetYa/Domain/UseCase/Protocol/QuotationFinishUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/Protocol/QuotationFinishUseCase.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 
 protocol QuotationFinishUseCase {
+    var pdfID: CurrentValueSubject<String, Never> { get set }
     var carInquery: PassthroughSubject<QuotationFinish, Never> { get set }
     var emailResult: PassthroughSubject<Bool, Never> { get set }
     

--- a/GetYa/GetYa/Domain/UseCase/Protocol/QuotationFinishUseCase.swift
+++ b/GetYa/GetYa/Domain/UseCase/Protocol/QuotationFinishUseCase.swift
@@ -12,7 +12,9 @@ protocol QuotationFinishUseCase {
     var pdfID: CurrentValueSubject<String, Never> { get set }
     var carInquery: PassthroughSubject<QuotationFinish, Never> { get set }
     var emailResult: PassthroughSubject<Bool, Never> { get set }
+    var pdfURL: PassthroughSubject<String, Never> { get set }
     
     func fetchCarInquery()
     func fetchEmail(email: String)
+    func fetchPdfURL()
 }

--- a/GetYa/GetYa/Presentation/CarSettingSelect/OptionSelect/ViewController/OptionSelectViewController.swift
+++ b/GetYa/GetYa/Presentation/CarSettingSelect/OptionSelect/ViewController/OptionSelectViewController.swift
@@ -26,7 +26,9 @@ class OptionSelectViewController: UIViewController {
     private var viewControllers: [UIViewController] = []
     private var currentSegmentedIndex: Int = 0 {
         didSet {
-            let direction: UIPageViewController.NavigationDirection = oldValue <= currentSegmentedIndex ? .forward : .reverse
+            let direction: UIPageViewController.NavigationDirection = oldValue <= currentSegmentedIndex
+            ? .forward
+            : .reverse
             self.pageViewController.setViewControllers(
                 [viewControllers[currentSegmentedIndex]],
                 direction: direction,

--- a/GetYa/GetYa/Presentation/Common/Model/MyActivityItemSource.swift
+++ b/GetYa/GetYa/Presentation/Common/Model/MyActivityItemSource.swift
@@ -1,0 +1,47 @@
+//
+//  MyActivityItemSource.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import LinkPresentation
+
+class MyActivityItemSource: NSObject, UIActivityItemSource {
+    var title: String
+    var text: String
+    
+    init(title: String, text: String) {
+        self.title = title
+        self.text = text
+        super.init()
+    }
+    
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return text
+    }
+    
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
+        return text
+    }
+    
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        subjectForActivityType activityType: UIActivity.ActivityType?
+    ) -> String {
+        return title
+    }
+
+    func activityViewControllerLinkMetadata(
+        _ activityViewController: UIActivityViewController
+    ) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = title
+        metadata.originalURL = URL(fileURLWithPath: text)
+        return metadata
+    }
+
+}

--- a/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
@@ -42,6 +42,7 @@ class LoadingViewController: UIViewController {
     // MARK: - Properties
     private let viewModel: LoadingViewModel
     private var cancellables = Set<AnyCancellable>()
+    private let viewDidLoadEvent = PassthroughSubject<Void, Never>()
     
     // MARK: - Lifecycles
     init(viewModel: LoadingViewModel) {
@@ -53,15 +54,15 @@ class LoadingViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        bind()
         setupViews()
         configureUI()
         
-        // TODO: 여기서 네트워크 요청이 완료되면 화면 dismiss 하도록 하기 (Lottie가 제대로 없어지는지 확인 필요)
         lottieView.play()
-        /// 임시적으로 3초뒤에 불러와진다고 가정
+        viewDidLoadEvent.send(())
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             let finishViewController = QuotationFinishViewController(
                 viewModel: QuotationFinishViewModel(
@@ -82,6 +83,12 @@ class LoadingViewController: UIViewController {
     }
     
     // MARK: - Private Functions
+    private func bind() {
+        let input = LoadingViewModel.Input(
+            viewDidLoadEvent: viewDidLoadEvent.eraseToAnyPublisher())
+        let output = viewModel.transform(input: input)
+    }
+    
     private func setupViews() {
         view.addSubviews([
             label,

--- a/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
@@ -85,13 +85,13 @@ class LoadingViewController: UIViewController {
                                 pdfID: pdfID,
                                 repository: DefaultQuotationFinishRepository(
                                     provider: SessionProvider()))))
+                    
                     if let navigationController,
                        let firstViewController = navigationController.viewControllers.first {
-                        navigationController.pushViewController(finishViewController, animated: true)
-                        navigationController.viewControllers.removeAll(where: { targetViewController in
-                            return (targetViewController != firstViewController &&
-                                    targetViewController != finishViewController)
-                        })
+                        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
+                            .removeAllViewContrllerExcept(
+                                to: firstViewController,
+                                nextViewController: finishViewController)
                     }
                 })
             .store(in: &cancellables)

--- a/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
@@ -115,6 +115,7 @@ class LoadingViewController: UIViewController {
     private func configureNavigationBar() {
         navigationItem.title = ""
         navigationItem.titleView = UIImageView(image: UIImage(named: "Black_Logo"))
+        navigationItem.setHidesBackButton(true, animated: true)
     }
     
     private func configureLabel() {

--- a/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewController/LoadingViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Lottie
+import Combine
 
 class LoadingViewController: UIViewController {
     enum Constants {
@@ -39,8 +40,20 @@ class LoadingViewController: UIViewController {
     }
     
     // MARK: - Properties
+    private let viewModel: LoadingViewModel
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Lifecycles
+    init(viewModel: LoadingViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()

--- a/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  LoadingViewModel.swift
+//  GetYa
+//
+//  Created by 배남석 on 2023/08/24.
+//
+
+import Foundation
+import Combine
+
+class LoadingViewModel {
+    // MARK: - Input
+    struct Input {
+        
+    }
+    
+    // MARK: - Output
+    struct Output {
+        
+    }
+    
+    // MARK: - Dependency
+    
+    // MARK: - Properties
+    private let useCase: LoadingUseCase
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - LifeCycle
+    init(useCase: LoadingUseCase) {
+        self.useCase = useCase
+    }
+    
+    // MARK: - Functions
+}

--- a/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 class LoadingViewModel {
     // MARK: - Input
     struct Input {
-        
+        let viewDidLoadEvent: AnyPublisher<Void, Never>
     }
     
     // MARK: - Output
@@ -23,12 +23,32 @@ class LoadingViewModel {
     
     // MARK: - Properties
     private let useCase: LoadingUseCase
+    private let contrationQuotation: ContractionQuotation
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
-    init(useCase: LoadingUseCase) {
+    init(contrationQuotation: ContractionQuotation, useCase: LoadingUseCase) {
         self.useCase = useCase
+        self.contrationQuotation = contrationQuotation
     }
     
     // MARK: - Functions
+    func transform(input: Input) -> Output {
+        let output = Output()
+        
+        input.viewDidLoadEvent
+            .sink(receiveValue: { [weak self] in
+                guard let self else { return }
+                useCase.fetchPdfID(contrationQuotation: contrationQuotation)
+            })
+            .store(in: &cancellables)
+        
+        useCase.pdfID
+            .sink(receiveValue: {
+                print($0)
+            })
+            .store(in: &cancellables)
+        
+        return output
+    }
 }

--- a/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
+++ b/GetYa/GetYa/Presentation/Loading/ViewModel/LoadingViewModel.swift
@@ -16,7 +16,7 @@ class LoadingViewModel {
     
     // MARK: - Output
     struct Output {
-        
+        let pdfID = PassthroughSubject<String, Never>()
     }
     
     // MARK: - Dependency
@@ -45,7 +45,7 @@ class LoadingViewModel {
         
         useCase.pdfID
             .sink(receiveValue: {
-                print($0)
+                output.pdfID.send($0)
             })
             .store(in: &cancellables)
         

--- a/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
@@ -103,8 +103,19 @@ class QuotationFinishViewController: BaseViewController {
     private let purchaseView = PurchaseView()
     private lazy var leftAndButtonStackView = LeftAndRightButtonStackView().set {
         $0.setLeftButton(title: "수정", handler: {
-            // TODO: 2.1 트림 선택 화면으로
-            print("수정")
+            if let trimViewControllerIndex = self.navigationController?
+                .viewControllers
+                .firstIndex(where: {
+                    $0 is TrimSelectViewController
+                }) {
+                print(trimViewControllerIndex)
+            } else {
+                guard let homeViewController = self.navigationController?.viewControllers.first else { return }
+                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
+                    .removeAllViewContrllerExcept(
+                        to: homeViewController,
+                        nextViewController: CarSettingSelectViewController(carSpecID: 1))
+            }
         })
         $0.setRightButton(title: "구매/상담", handler: {
             guard let url = URL(string: "https://www.hyundai.com/kr/ko/e/vehicles/purchase-consult") else { return }
@@ -414,7 +425,6 @@ class QuotationFinishViewController: BaseViewController {
         totalNameAndPriceView.setPrice(value: carInquery.basicPrice)
         purchaseView.setTotalPrice(totalPrice: carInquery.totalPrice)
     }
-    
     
     // MARK: - Functions
     override func touchUpNavigationBackButton() {

--- a/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
@@ -125,7 +125,8 @@ class QuotationFinishViewController: BaseViewController {
         $0.addAction(UIAction(handler: { _ in
             self.showAlert(
                 type: .mail,
-                buttonType: .oneButton,
+                buttonType: .twoButton,
+                leftTitle: "아니요",
                 rightTitle: "보내기")
         }), for: .touchUpInside)
     }

--- a/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationFinish/ViewController/QuotationFinishViewController.swift
@@ -11,7 +11,62 @@ import Combine
 
 class QuotationFinishViewController: BaseViewController {
     enum Constatns {
-        
+        enum ThumbnailView {
+            static let height: CGFloat = .toScaledHeight(value: 440)
+        }
+        enum CarInfoView {
+            static let height: CGFloat = .toScaledHeight(value: 89)
+        }
+        enum QoutateTableView {
+            static let basicHeight: CGFloat = .toScaledHeight(value: 3)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+        }
+        enum TotalNameAndPriceView {
+            static let topMargin: CGFloat = .toScaledHeight(value: 16)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+            static let height: CGFloat = .toScaledHeight(value: 24)
+        }
+        enum ShareButton {
+            static let topMargin: CGFloat = .toScaledHeight(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+            static let height: CGFloat = .toScaledHeight(value: 40)
+            static let width: CGFloat = .toScaledHeight(value: 40)
+        }
+        enum PDFButton {
+            static let topMargin: CGFloat = .toScaledHeight(value: 32)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let height: CGFloat = .toScaledHeight(value: 52)
+            static let width: CGFloat = .toScaledWidth(value: 168)
+        }
+        enum MailButton {
+            static let topMargin: CGFloat = .toScaledHeight(value: 32)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+            static let height: CGFloat = .toScaledHeight(value: 52)
+            static let width: CGFloat = .toScaledWidth(value: 168)
+        }
+        enum StoreButton {
+            static let topMargin: CGFloat = .toScaledHeight(value: 8)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+            static let height: CGFloat = .toScaledHeight(value: 52)
+        }
+        enum LineView {
+            static let topMargin: CGFloat = .toScaledHeight(value: 24)
+            static let height: CGFloat = .toScaledHeight(value: 4)
+        }
+        enum PurchaseView {
+            static let topMargin: CGFloat = .toScaledHeight(value: 20)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+        }
+        enum LeftAndButtonStackView {
+            static let topMargin: CGFloat = .toScaledHeight(value: 40)
+            static let leadingMargin: CGFloat = .toScaledWidth(value: 16)
+            static let trailingMargin: CGFloat = .toScaledWidth(value: -16)
+            static let height: CGFloat = .toScaledHeight(value: 52)
+        }
     }
     
     // MARK: - UI properties
@@ -256,35 +311,40 @@ class QuotationFinishViewController: BaseViewController {
     }
     
     private func configureThumbnailView() {
+        typealias Const = Constatns.ThumbnailView
+        
         NSLayoutConstraint.activate([
             thumbnailView.topAnchor.constraint(equalTo: contentView.topAnchor),
             thumbnailView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             thumbnailView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            thumbnailView.heightAnchor.constraint(equalToConstant: CGFloat(440).scaledHeight)
+            thumbnailView.heightAnchor.constraint(equalToConstant: Const.height)
         ])
     }
     
     private func configureCarInfoView() {
+        typealias Const = Constatns.CarInfoView
+        
         NSLayoutConstraint.activate([
             carInfoView.topAnchor.constraint(equalTo: thumbnailView.bottomAnchor),
             carInfoView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             carInfoView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            carInfoView.heightAnchor.constraint(equalToConstant: CGFloat(89).scaledHeight)
+            carInfoView.heightAnchor.constraint(equalToConstant: Const.height)
         ])
     }
     
     private func configureQuotationTableView() {
+        typealias Const = Constatns.QoutateTableView
         typealias ConstTable = QuotationTableView.Constants
         quotateTableViewTopConstraint = qoutateTableView.heightAnchor.constraint(
-            equalToConstant: ConstTable.headerHeight * 2 + CGFloat(3).scaledHeight)
+            equalToConstant: ConstTable.headerHeight * 2 + Const.basicHeight)
         NSLayoutConstraint.activate([
             qoutateTableView.topAnchor.constraint(equalTo: carInfoView.bottomAnchor),
             qoutateTableView.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
+                constant: Const.leadingMargin),
             qoutateTableView.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
+                constant: Const.trailingMargin),
             quotateTableViewTopConstraint
         ])
     }
@@ -302,109 +362,127 @@ class QuotationFinishViewController: BaseViewController {
     }
     
     private func configureTotalNameAndPriceView() {
+        typealias Const = Constatns.TotalNameAndPriceView
+        
         NSLayoutConstraint.activate([
             totalNameAndPriceView.topAnchor.constraint(
                 equalTo: qoutateTableView.bottomAnchor,
-                constant: CGFloat(16).scaledHeight),
+                constant: Const.topMargin),
             totalNameAndPriceView.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
+                constant: Const.leadingMargin),
             totalNameAndPriceView.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
-            totalNameAndPriceView.heightAnchor.constraint(equalToConstant: 24)
+                constant: Const.trailingMargin),
+            totalNameAndPriceView.heightAnchor.constraint(equalToConstant: Const.height)
         ])
     }
     
     private func configureShareButton() {
-        shareButton.layer.cornerRadius = CGFloat(40).scaledHeight / 2
+        typealias Const = Constatns.ShareButton
+        
+        shareButton.layer.cornerRadius = Const.height / 2
         
         NSLayoutConstraint.activate([
             shareButton.topAnchor.constraint(
                 equalTo: thumbnailView.imageView.topAnchor,
-                constant: CGFloat(16).scaledHeight),
+                constant: Const.topMargin),
             shareButton.trailingAnchor.constraint(
                 equalTo: thumbnailView.imageView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
-            shareButton.heightAnchor.constraint(equalToConstant: CGFloat(40).scaledHeight),
-            shareButton.widthAnchor.constraint(equalToConstant: CGFloat(40).scaledHeight)
+                constant: Const.trailingMargin),
+            shareButton.heightAnchor.constraint(equalToConstant: Const.height),
+            shareButton.widthAnchor.constraint(equalToConstant: Const.width)
         ])
     }
     
     private func configurePDFButton() {
+        typealias Const = Constatns.PDFButton
+        
         NSLayoutConstraint.activate([
             pdfButton.topAnchor.constraint(
                 equalTo: totalNameAndPriceView.bottomAnchor,
-                constant: CGFloat(32).scaledHeight),
+                constant: Const.topMargin),
             pdfButton.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
-            pdfButton.heightAnchor.constraint(equalToConstant: CGFloat(52).scaledHeight),
-            pdfButton.widthAnchor.constraint(equalToConstant: CGFloat(168).scaledWidth)
+                constant: Const.leadingMargin),
+            pdfButton.heightAnchor.constraint(equalToConstant: Const.height),
+            pdfButton.widthAnchor.constraint(equalToConstant: Const.width)
         ])
     }
     
     private func configureMailButton() {
+        typealias Const = Constatns.MailButton
+        
         NSLayoutConstraint.activate([
             mailButton.topAnchor.constraint(
                 equalTo: totalNameAndPriceView.bottomAnchor,
-                constant: CGFloat(32).scaledHeight),
+                constant: Const.topMargin),
             mailButton.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
-            mailButton.heightAnchor.constraint(equalToConstant: CGFloat(52).scaledHeight),
-            mailButton.widthAnchor.constraint(equalToConstant: CGFloat(168).scaledWidth)
+                constant: Const.trailingMargin),
+            mailButton.heightAnchor.constraint(equalToConstant: Const.height),
+            mailButton.widthAnchor.constraint(equalToConstant: Const.width)
         ])
     }
     
     private func configureStoreButton() {
+        typealias Const = Constatns.StoreButton
+        
         NSLayoutConstraint.activate([
             storeButton.topAnchor.constraint(
                 equalTo: pdfButton.bottomAnchor,
-                constant: CGFloat(8).scaledHeight),
+                constant: Const.topMargin),
             storeButton.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
+                constant: Const.leadingMargin),
             storeButton.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
-            storeButton.heightAnchor.constraint(equalToConstant: CGFloat(52).scaledHeight)
+                constant: Const.trailingMargin),
+            storeButton.heightAnchor.constraint(equalToConstant: Const.height)
         ])
     }
     
     private func configureLineView() {
+        typealias Const = Constatns.LineView
+        
         NSLayoutConstraint.activate([
-            lineView.topAnchor.constraint(equalTo: storeButton.bottomAnchor, constant: CGFloat(24).scaledHeight),
+            lineView.topAnchor.constraint(equalTo: storeButton.bottomAnchor, constant: Const.topMargin),
             lineView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             lineView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            lineView.heightAnchor.constraint(equalToConstant: CGFloat(4).scaledHeight)
+            lineView.heightAnchor.constraint(equalToConstant: Const.height)
         ])
     }
     
     private func configurePurchaseView() {
+        typealias Const = Constatns.PurchaseView
+        
         NSLayoutConstraint.activate([
-            purchaseView.topAnchor.constraint(equalTo: lineView.bottomAnchor, constant: CGFloat(20).scaledHeight),
+            purchaseView.topAnchor.constraint(
+                equalTo: lineView.bottomAnchor,
+                constant: Const.topMargin),
             purchaseView.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
+                constant: Const.leadingMargin),
             purchaseView.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth)
+                constant: Const.trailingMargin)
         ])
     }
     
     private func configureLeftAndRightStackView() {
+        typealias Const = Constatns.LeftAndButtonStackView
+        
         NSLayoutConstraint.activate([
             leftAndButtonStackView.topAnchor.constraint(
                 equalTo: purchaseView.bottomAnchor,
-                constant: CGFloat(40).scaledHeight),
+                constant: Const.topMargin),
             leftAndButtonStackView.leadingAnchor.constraint(
                 equalTo: contentView.leadingAnchor,
-                constant: CGFloat(16).scaledWidth),
+                constant: Const.leadingMargin),
             leftAndButtonStackView.trailingAnchor.constraint(
                 equalTo: contentView.trailingAnchor,
-                constant: CGFloat(-16).scaledWidth),
-            leftAndButtonStackView.heightAnchor.constraint(equalToConstant: CGFloat(52).scaledHeight),
+                constant: Const.trailingMargin),
+            leftAndButtonStackView.heightAnchor.constraint(equalToConstant: Const.height),
             leftAndButtonStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }

--- a/GetYa/GetYa/Presentation/QuotationFinish/ViewModel/QuotationFinishViewModel.swift
+++ b/GetYa/GetYa/Presentation/QuotationFinish/ViewModel/QuotationFinishViewModel.swift
@@ -13,12 +13,14 @@ class QuotationFinishViewModel {
     struct Input {
         let viewDidLoadEvent: AnyPublisher<Void, Never>
         let postEmailEvent: AnyPublisher<String, Never>
+        let touchUpShareButtonEvent: AnyPublisher<Void, Never>
     }
     
     // MARK: - Output
     struct Output {
         let carInquery = PassthroughSubject<QuotationFinish, Never>()
         let emailResult = PassthroughSubject<Bool, Never>()
+        let pdfID = PassthroughSubject<String, Never>()
     }
     
     // MARK: - Dependency
@@ -47,6 +49,13 @@ class QuotationFinishViewModel {
             .sink(receiveValue: { [weak self] in
                 guard let self else { return }
                 useCase.fetchEmail(email: $0)
+            })
+            .store(in: &cancellables)
+        
+        input.touchUpShareButtonEvent
+            .sink(receiveValue: { [weak self] in
+                guard let self else { return }
+                output.pdfID.send(useCase.pdfID.value)
             })
             .store(in: &cancellables)
         

--- a/GetYa/GetYa/Presentation/QuotationFinish/ViewModel/QuotationFinishViewModel.swift
+++ b/GetYa/GetYa/Presentation/QuotationFinish/ViewModel/QuotationFinishViewModel.swift
@@ -14,6 +14,7 @@ class QuotationFinishViewModel {
         let viewDidLoadEvent: AnyPublisher<Void, Never>
         let postEmailEvent: AnyPublisher<String, Never>
         let touchUpShareButtonEvent: AnyPublisher<Void, Never>
+        let touchUpPDFButtonEvent: AnyPublisher<Void, Never>
     }
     
     // MARK: - Output
@@ -21,6 +22,7 @@ class QuotationFinishViewModel {
         let carInquery = PassthroughSubject<QuotationFinish, Never>()
         let emailResult = PassthroughSubject<Bool, Never>()
         let pdfID = PassthroughSubject<String, Never>()
+        let pdfURL = PassthroughSubject<String, Never>()
     }
     
     // MARK: - Dependency
@@ -59,6 +61,13 @@ class QuotationFinishViewModel {
             })
             .store(in: &cancellables)
         
+        input.touchUpPDFButtonEvent
+            .sink(receiveValue: { [weak self] in
+                guard let self else { return }
+                useCase.fetchPdfURL()
+            })
+            .store(in: &cancellables)
+        
         useCase.carInquery
             .sink(receiveValue: {
                 output.carInquery.send($0)
@@ -68,6 +77,12 @@ class QuotationFinishViewModel {
         useCase.emailResult
             .sink(receiveValue: {
                 output.emailResult.send($0)
+            })
+            .store(in: &cancellables)
+        
+        useCase.pdfURL
+            .sink(receiveValue: {
+                output.pdfURL.send($0)
             })
             .store(in: &cancellables)
         

--- a/GetYa/GetYa/Presentation/QuotationPreview/DefaultQuotationPreview/DefaultQuotationPreviewViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationPreview/DefaultQuotationPreview/DefaultQuotationPreviewViewController.swift
@@ -77,7 +77,13 @@ extension DefaultQuotationPreviewViewController: CustomOrQuoteSelectViewDelegate
     }
     
     func gotoQuotePage() {
-        navigationController?.pushViewController(LoadingViewController(), animated: true)
+        navigationController?.pushViewController(
+            LoadingViewController(
+                viewModel: LoadingViewModel(
+                    useCase: DefaultLoadingUseCase(
+                        repository: DefaultLoadingRepository(
+                            provider: SessionProvider())))),
+            animated: true)
     }
 }
 

--- a/GetYa/GetYa/Presentation/QuotationPreview/DefaultQuotationPreview/DefaultQuotationPreviewViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationPreview/DefaultQuotationPreview/DefaultQuotationPreviewViewController.swift
@@ -80,6 +80,12 @@ extension DefaultQuotationPreviewViewController: CustomOrQuoteSelectViewDelegate
         navigationController?.pushViewController(
             LoadingViewController(
                 viewModel: LoadingViewModel(
+                    contrationQuotation: ContractionQuotation(
+                        carSpecID: 1,
+                        trimID: 1,
+                        exteriorColorID: 1,
+                        interiorColorID: 1,
+                        additionalOptionIDList: []),
                     useCase: DefaultLoadingUseCase(
                         repository: DefaultLoadingRepository(
                             provider: SessionProvider())))),

--- a/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
@@ -68,6 +68,12 @@ extension DetailQuotationPreviewViewController: CustomOrQuoteSelectViewDelegate 
         navigationController?.pushViewController(
             LoadingViewController(
                 viewModel: LoadingViewModel(
+                    contrationQuotation: ContractionQuotation(
+                        carSpecID: 1,
+                        trimID: 1,
+                        exteriorColorID: 1,
+                        interiorColorID: 1,
+                        additionalOptionIDList: []),
                     useCase: DefaultLoadingUseCase(
                         repository: DefaultLoadingRepository(
                             provider: SessionProvider())))),

--- a/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
@@ -65,7 +65,6 @@ extension DetailQuotationPreviewViewController: CustomOrQuoteSelectViewDelegate 
     }
     
     func gotoQuotePage() {
-        // TODO: 로딩 페이지 후 서버에서 완료되면 5.1화면으로 이동
         navigationController?.pushViewController(
             LoadingViewController(
                 viewModel: LoadingViewModel(

--- a/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
+++ b/GetYa/GetYa/Presentation/QuotationPreview/DetailQuotationPreview/ViewController/DetailQuotationPreviewViewController.swift
@@ -66,7 +66,13 @@ extension DetailQuotationPreviewViewController: CustomOrQuoteSelectViewDelegate 
     
     func gotoQuotePage() {
         // TODO: 로딩 페이지 후 서버에서 완료되면 5.1화면으로 이동
-        navigationController?.pushViewController(LoadingViewController(), animated: true)
+        navigationController?.pushViewController(
+            LoadingViewController(
+                viewModel: LoadingViewModel(
+                    useCase: DefaultLoadingUseCase(
+                        repository: DefaultLoadingRepository(
+                            provider: SessionProvider())))),
+            animated: true)
     }
 }
 

--- a/GetYa/GetYa/Util/Extension/UIViewController+.swift
+++ b/GetYa/GetYa/Util/Extension/UIViewController+.swift
@@ -49,7 +49,9 @@ extension UIViewController {
                 handler: {
                     self.dismiss(animated: false, completion: {
                         let activityVC = UIActivityViewController(
-                            activityItems: [urlString],
+                            activityItems: [MyActivityItemSource(
+                                title: "내 차 만들기 견적을 공유합니다.",
+                                text: urlString)],
                             applicationActivities: nil)
                         activityVC.popoverPresentationController?.sourceView = self.view
                         activityVC.popoverPresentationController?.sourceRect = CGRect(

--- a/GetYa/GetYa/Util/Protocol/Responsable.swift
+++ b/GetYa/GetYa/Util/Protocol/Responsable.swift
@@ -29,6 +29,7 @@ enum ResponseType {
     case pdfID
     case pdfCarInfomation(pdfID: String)
     case pdfEmail(pdfEmail: PdfEmail)
+    case pdfURL(pdfID: String)
     
     var path: String {
         switch self {
@@ -46,6 +47,8 @@ enum ResponseType {
             return "pdf/\(pdfID)/car-information"
         case .pdfEmail(let pdfEmail):
             return "pdf/\(pdfEmail.pdfID)/email/\(pdfEmail.emailName)"
+        case .pdfURL(let pdfID):
+            return "pdf/\(pdfID)"
         default:
             break
         }

--- a/GetYa/GetYa/Util/Protocol/Responsable.swift
+++ b/GetYa/GetYa/Util/Protocol/Responsable.swift
@@ -26,6 +26,7 @@ enum ResponseType {
     case packageOptionsActivityLog(optionId: Int)
     case optionPackageDetails(optionId: Int)
     case optionCarSpecIdTagsTagId(carSpecId: Int, tagId: Int)
+    case pdfID
     case pdfCarInfomation(pdfID: String)
     case pdfEmail(pdfEmail: PdfEmail)
     
@@ -39,6 +40,8 @@ enum ResponseType {
             return "car-spec"
         case .carSpecAdditionalOption(let carSpecId):
             return "car-spec/\(carSpecId)/additional-options"
+        case .pdfID:
+            return "pdfId"
         case .pdfCarInfomation(let pdfID):
             return "pdf/\(pdfID)/car-information"
         case .pdfEmail(let pdfEmail):


### PR DESCRIPTION
🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [x]  반드시 확인할 것! **pull a topic/feature/bugfix branch** 에서 develop branch로 PR요청하는지 확인하세요. master/main에 하시면 안됩니다.

- [x]  커밋 또는 모든 커밋의 메시지 스타일이 요청한 구조와 일치하는지 확인해주세요.

- [x] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## 📌 [요약]

*<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->*

*<!-- 구현한 feature를 요약해주세요.  -->*

## ✨ [작업 내용]

*<!-- 작업한 기능 대한 설명을 적어주세요 -->*
- 5.1 화면을 가기 전 로딩화면에서 PDF ID를 받고, 5.1 화면에게 주입해줍니다.
- 네비게이션 컨트롤러의 삭제 기능을 SceneDelegate에게 넘겨서 제대로 처리될 수 있도록 구현함
- 5.1 화면에서 일어나는 모든 이벤트에 API 연결
- UIActivityViewController의 ShareSheet를 Custom 하기위해서 MyActivityItemSource 생성 및 적용

## 📸  [스크린샷(선택)]

*<!-- 스크린샷이 필요하면 스크린샷을 첨부해주세요 -->*
### 직접 클론 받아서 돌려보길 적극 추천드립니다.

## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

*<!-- 참고할 사항이 있다면 적어주세요 -->*
